### PR TITLE
Windows support for creating search adapters

### DIFF
--- a/src/Adapter/AdapterFactory.php
+++ b/src/Adapter/AdapterFactory.php
@@ -88,6 +88,14 @@ final class AdapterFactory
             if (\str_contains($dsn, ':///')) {
                 // make DSN like loupe:///full/path/project/var/indexes parseable
                 $dsn = \str_replace(':///', '://' . $adapterName . '/', $dsn);
+            } elseif (\DIRECTORY_SEPARATOR === '\\') {
+                // might be Windows and contain an absolute path like loupe://C:\path\project\var\indexes which will fail when parse_url is used
+                $dsnParts = explode('://', $dsn);
+                return [
+                    'host' => '',
+                    'scheme' => $dsnParts[0] ?? null,
+                    'path' => $dsnParts[1] ?? null
+                ];
             } else {
                 $dsn = $dsn . '@' . $adapterName . $query;
             }


### PR DESCRIPTION
### Description

This PR adds `Windows` support for the path resolution since `$dsn` would fail later due to the second `parse_url` attempt returning `false` again.

In my case, `loupe://C:\path\project\var\indexes` will fail because it won't detect any scheme at all.
The early return is done before adding the fallback where it adds the adapter name with an `@´  :')

Unsure if we should go for the `PHP_OS_FAMILY` check and see if it's windows in this case 🤔?

Windows did fail previously due to an undefined array key within the following line not having a scheme at all;
https://github.com/schranz-search/seal/blob/9e17f9be173ca46853976d594ae12e536f90dc12/src/Adapter/AdapterFactory.php#L140